### PR TITLE
Apply undefined/null property logic to className

### DIFF
--- a/src/render-to-string.js
+++ b/src/render-to-string.js
@@ -123,7 +123,7 @@ function renderToString(element) {
         } else if (prop === 'style') {
           html += ` style="${stringifyStyles(value)}"`
         } else if (prop === 'class' || prop === 'className') {
-          html += ` class="${escapeString(value)}"`
+          html += value ? ` class="${escapeString(value)}"` : ''
         } else if (prop === 'dangerouslySetInnerHTML') {
           innerHTML = value.__html
         } else {

--- a/test/spec.js
+++ b/test/spec.js
@@ -65,7 +65,7 @@ describe('Hyperons', () => {
     })
 
     it('does not render null or undefined HTML attributes', () => {
-      const result = h('div', { itemtype: null, itemprop: undefined })
+      const result = h('div', { itemtype: null, itemprop: undefined, className: undefined })
       expect(render(result)).to.equal('<div></div>')
     })
 


### PR DESCRIPTION
Currently because `class` and `className` are handled differently to
other attributes, they are rendering `undefined` and `null` as strings
rather than ignoring the attributes entirely.

I've reduced my code down to bare-bones to demonstrate. Didn't want to
actually commit, but running this in the repo:

```js
const {h, render} = require('.');
const el = h('div', {className: undefined});
console.log(render(el));
```

results in:

```html
<div class="undefined"></div>
```

I don't know whether my solution is ideal. Or whether this is even
considered a bug, I'm new to all this fancy stuff 🤷‍♂️

Let me know if you'd like anything changed.